### PR TITLE
Use `HTMLMediaElement.srcObject` instead or createObjectURL.

### DIFF
--- a/client/webrtc.js
+++ b/client/webrtc.js
@@ -33,7 +33,7 @@ function pageReady() {
 
 function getUserMediaSuccess(stream) {
     localStream = stream;
-    localVideo.src = window.URL.createObjectURL(stream);
+    localVideo.srcObject = stream;
 }
 
 function start(isCaller) {
@@ -83,7 +83,7 @@ function createdDescription(description) {
 
 function gotRemoteStream(event) {
     console.log('got remote stream');
-    remoteVideo.src = window.URL.createObjectURL(event.stream);
+    remoteVideo.srcObject = event.stream;
 }
 
 function errorHandler(error) {


### PR DESCRIPTION
`createObjectURL` from stream not allowed in Safari.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject
https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL